### PR TITLE
Use CSS instead of JavaScript for overlay and to reference images (close button, loading status)

### DIFF
--- a/coffee/lightbox.coffee
+++ b/coffee/lightbox.coffee
@@ -45,8 +45,6 @@ $ = jQuery
 
 class LightboxOptions
   constructor: ->
-    @fileLoadingImage = 'images/loading.gif'     
-    @fileCloseImage = 'images/close.png'
     @resizeDuration = 700
     @fadeDuration = 500
     @labelImage = "Image" # Change to localize to non-english language
@@ -86,9 +84,7 @@ class Lightbox
               $('<a/>', class: 'lb-next')
             ),
             $('<div/>', class: 'lb-loader').append(
-              $('<a/>', class: 'lb-cancel').append(
-                $('<img/>', src: @options.fileLoadingImage)
-              )
+              $('<a/>', class: 'lb-cancel')
             )
           )
         ),
@@ -99,9 +95,7 @@ class Lightbox
               $('<span/>', class: 'lb-number')
             ),
             $('<div/>', class: 'lb-closeContainer').append(
-              $('<a/>', class: 'lb-close').append(
-                $('<img/>', src: @options.fileCloseImage)
-              )
+              $('<a/>', class: 'lb-close')
             )
           )
         )
@@ -143,12 +137,8 @@ class Lightbox
 
   # Show overlay and lightbox. If the image is part of a set, add siblings to album array.
   start: ($link) ->
-    $(window).on "resize", @sizeOverlay
-
     $('select, object, embed').css visibility: "hidden"
     $('#lightboxOverlay')
-      .width( $(document).width())
-      .height( $(document).height() )
       .fadeIn( @options.fadeDuration )
 
     @album = []
@@ -186,7 +176,6 @@ class Lightbox
     $lightbox = $('#lightbox')
     $image = $lightbox.find('.lb-image')
 
-    @sizeOverlay()
     $('#lightboxOverlay').fadeIn( @options.fadeDuration )
     
     $('.loader').fadeIn 'slow'
@@ -209,13 +198,6 @@ class Lightbox
     return  
 
 
-  # Stretch overlay to fit the document
-  sizeOverlay: () ->
-    $('#lightboxOverlay')
-      .width( $(document).width())
-      .height( $(document).height() )
-  
-  
   # Animate the size of the lightbox to fit the image we are showing
   sizeContainer: (imageWidth, imageHeight) ->
     $lightbox = $('#lightbox')
@@ -301,8 +283,7 @@ class Lightbox
     $lightbox.find('.lb-outerContainer').removeClass 'animating'
     
     $lightbox.find('.lb-dataContainer')
-      .fadeIn @resizeDuration, () =>
-        @sizeOverlay()
+      .fadeIn @resizeDuration
     return
     
     
@@ -350,7 +331,6 @@ class Lightbox
   # Closing time. :-(
   end: ->
     @disableKeyboardNav()
-    $(window).off "resize", @sizeOverlay
     $('#lightbox').fadeOut @options.fadeDuration
     $('#lightboxOverlay').fadeOut @options.fadeDuration
     $('select, object, embed').css visibility: "visible"

--- a/css/lightbox.css
+++ b/css/lightbox.css
@@ -1,7 +1,9 @@
 /* line 6, ../sass/lightbox.sass */
 #lightboxOverlay {
-  position: absolute;
+  position: fixed;
   top: 0;
+  right:0;
+  bottom:0;
   left: 0;
   z-index: 9999;
   background-color: black;
@@ -174,8 +176,17 @@
   float: right;
   padding-bottom: 0.7em;
   outline: none;
+  
+  height:35px;
+  background:url("../images/close.png") no-repeat scroll 0 0 transparent;
 }
 /* line 117, ../sass/lightbox.sass */
 .lb-data .lb-close:hover {
   cursor: pointer;
+}
+.lb-cancel {
+    background: url("../images/loading.gif") repeat scroll 0 0 transparent;
+    display: inline-block;
+    height: 32px;
+    width: 32px;
 }

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -1,90 +1,75 @@
-
-/*
-Lightbox v2.51
-by Lokesh Dhakar - http://www.lokeshdhakar.com
-
-For more information, visit:
-http://lokeshdhakar.com/projects/lightbox2/
-
-Licensed under the Creative Commons Attribution 2.5 License - http://creativecommons.org/licenses/by/2.5/
-- free for use in both personal and commercial projects
-- attribution requires leaving author name, author link, and the license info intact
-	
-Thanks
-- Scott Upton(uptonic.com), Peter-Paul Koch(quirksmode.com), and Thomas Fuchs(mir.aculo.us) for ideas, libs, and snippets.
-- Artemy Tregubenko (arty.name) for cleanup and help in updating to latest proto-aculous in v2.05.
-
-
-Table of Contents
-=================
-LightboxOptions
-
-Lightbox
-- constructor
-- init
-- enable
-- build
-- start
-- changeImage
-- sizeContainer
-- showImage
-- updateNav
-- updateDetails
-- preloadNeigbhoringImages
-- enableKeyboardNav
-- disableKeyboardNav
-- keyboardAction
-- end
-
-options = new LightboxOptions
-lightbox = new Lightbox options
-*/
-
 (function() {
-  var $, Lightbox, LightboxOptions;
-
+  /*
+  Lightbox v2.51
+  by Lokesh Dhakar - http://www.lokeshdhakar.com
+  
+  For more information, visit:
+  http://lokeshdhakar.com/projects/lightbox2/
+  
+  Licensed under the Creative Commons Attribution 2.5 License - http://creativecommons.org/licenses/by/2.5/
+  - free for use in both personal and commercial projects
+  - attribution requires leaving author name, author link, and the license info intact
+  	
+  Thanks
+  - Scott Upton(uptonic.com), Peter-Paul Koch(quirksmode.com), and Thomas Fuchs(mir.aculo.us) for ideas, libs, and snippets.
+  - Artemy Tregubenko (arty.name) for cleanup and help in updating to latest proto-aculous in v2.05.
+  
+  
+  Table of Contents
+  =================
+  LightboxOptions
+  
+  Lightbox
+  - constructor
+  - init
+  - enable
+  - build
+  - start
+  - changeImage
+  - sizeContainer
+  - showImage
+  - updateNav
+  - updateDetails
+  - preloadNeigbhoringImages
+  - enableKeyboardNav
+  - disableKeyboardNav
+  - keyboardAction
+  - end
+  
+  options = new LightboxOptions
+  lightbox = new Lightbox options
+  
+  */  var $, Lightbox, LightboxOptions;
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
   $ = jQuery;
-
   LightboxOptions = (function() {
-
     function LightboxOptions() {
-      this.fileLoadingImage = 'images/loading.gif';
-      this.fileCloseImage = 'images/close.png';
       this.resizeDuration = 700;
       this.fadeDuration = 500;
       this.labelImage = "Image";
       this.labelOf = "of";
     }
-
     return LightboxOptions;
-
   })();
-
   Lightbox = (function() {
-
     function Lightbox(options) {
       this.options = options;
       this.album = [];
       this.currentImageIndex = void 0;
       this.init();
     }
-
     Lightbox.prototype.init = function() {
       this.enable();
       return this.build();
     };
-
     Lightbox.prototype.enable = function() {
-      var _this = this;
-      return $('body').on('click', 'a[rel^=lightbox], area[rel^=lightbox]', function(e) {
-        _this.start($(e.currentTarget));
+      return $('body').on('click', 'a[rel^=lightbox], area[rel^=lightbox]', __bind(function(e) {
+        this.start($(e.currentTarget));
         return false;
-      });
+      }, this));
     };
-
     Lightbox.prototype.build = function() {
-      var $lightbox,
-        _this = this;
+      var $lightbox;
       $("<div>", {
         id: 'lightboxOverlay'
       }).after($('<div/>', {
@@ -105,9 +90,7 @@ lightbox = new Lightbox options
         "class": 'lb-loader'
       }).append($('<a/>', {
         "class": 'lb-cancel'
-      }).append($('<img/>', {
-        src: this.options.fileLoadingImage
-      }))))), $('<div/>', {
+      })))), $('<div/>', {
         "class": 'lb-dataContainer'
       }).append($('<div/>', {
         "class": 'lb-data'
@@ -121,43 +104,43 @@ lightbox = new Lightbox options
         "class": 'lb-closeContainer'
       }).append($('<a/>', {
         "class": 'lb-close'
-      }).append($('<img/>', {
-        src: this.options.fileCloseImage
-      }))))))).appendTo($('body'));
-      $('#lightboxOverlay').hide().on('click', function(e) {
-        _this.end();
+      })))))).appendTo($('body'));
+      $('#lightboxOverlay').hide().on('click', __bind(function(e) {
+        this.end();
         return false;
-      });
+      }, this));
       $lightbox = $('#lightbox');
-      $lightbox.hide().on('click', function(e) {
-        if ($(e.target).attr('id') === 'lightbox') _this.end();
+      $lightbox.hide().on('click', __bind(function(e) {
+        if ($(e.target).attr('id') === 'lightbox') {
+          this.end();
+        }
         return false;
-      });
-      $lightbox.find('.lb-outerContainer').on('click', function(e) {
-        if ($(e.target).attr('id') === 'lightbox') _this.end();
+      }, this));
+      $lightbox.find('.lb-outerContainer').on('click', __bind(function(e) {
+        if ($(e.target).attr('id') === 'lightbox') {
+          this.end();
+        }
         return false;
-      });
-      $lightbox.find('.lb-prev').on('click', function(e) {
-        _this.changeImage(_this.currentImageIndex - 1);
+      }, this));
+      $lightbox.find('.lb-prev').on('click', __bind(function(e) {
+        this.changeImage(this.currentImageIndex - 1);
         return false;
-      });
-      $lightbox.find('.lb-next').on('click', function(e) {
-        _this.changeImage(_this.currentImageIndex + 1);
+      }, this));
+      $lightbox.find('.lb-next').on('click', __bind(function(e) {
+        this.changeImage(this.currentImageIndex + 1);
         return false;
-      });
-      $lightbox.find('.lb-loader, .lb-close').on('click', function(e) {
-        _this.end();
+      }, this));
+      $lightbox.find('.lb-loader, .lb-close').on('click', __bind(function(e) {
+        this.end();
         return false;
-      });
+      }, this));
     };
-
     Lightbox.prototype.start = function($link) {
       var $lightbox, $window, a, i, imageNumber, left, top, _len, _ref;
-      $(window).on("resize", this.sizeOverlay);
       $('select, object, embed').css({
         visibility: "hidden"
       });
-      $('#lightboxOverlay').width($(document).width()).height($(document).height()).fadeIn(this.options.fadeDuration);
+      $('#lightboxOverlay').fadeIn(this.options.fadeDuration);
       this.album = [];
       imageNumber = 0;
       if ($link.attr('rel') === 'lightbox') {
@@ -173,7 +156,9 @@ lightbox = new Lightbox options
             link: $(a).attr('href'),
             title: $(a).attr('title')
           });
-          if ($(a).attr('href') === $link.attr('href')) imageNumber = i;
+          if ($(a).attr('href') === $link.attr('href')) {
+            imageNumber = i;
+          }
         }
       }
       $window = $(window);
@@ -186,36 +171,27 @@ lightbox = new Lightbox options
       }).fadeIn(this.options.fadeDuration);
       this.changeImage(imageNumber);
     };
-
     Lightbox.prototype.changeImage = function(imageNumber) {
-      var $image, $lightbox, preloader,
-        _this = this;
+      var $image, $lightbox, preloader;
       this.disableKeyboardNav();
       $lightbox = $('#lightbox');
       $image = $lightbox.find('.lb-image');
-      this.sizeOverlay();
       $('#lightboxOverlay').fadeIn(this.options.fadeDuration);
       $('.loader').fadeIn('slow');
       $lightbox.find('.lb-image, .lb-nav, .lb-prev, .lb-next, .lb-dataContainer, .lb-numbers, .lb-caption').hide();
       $lightbox.find('.lb-outerContainer').addClass('animating');
       preloader = new Image;
-      preloader.onload = function() {
-        $image.attr('src', _this.album[imageNumber].link);
+      preloader.onload = __bind(function() {
+        $image.attr('src', this.album[imageNumber].link);
         $image.width = preloader.width;
         $image.height = preloader.height;
-        return _this.sizeContainer(preloader.width, preloader.height);
-      };
+        return this.sizeContainer(preloader.width, preloader.height);
+      }, this);
       preloader.src = this.album[imageNumber].link;
       this.currentImageIndex = imageNumber;
     };
-
-    Lightbox.prototype.sizeOverlay = function() {
-      return $('#lightboxOverlay').width($(document).width()).height($(document).height());
-    };
-
     Lightbox.prototype.sizeContainer = function(imageWidth, imageHeight) {
-      var $container, $lightbox, $outerContainer, containerBottomPadding, containerLeftPadding, containerRightPadding, containerTopPadding, newHeight, newWidth, oldHeight, oldWidth,
-        _this = this;
+      var $container, $lightbox, $outerContainer, containerBottomPadding, containerLeftPadding, containerRightPadding, containerTopPadding, newHeight, newWidth, oldHeight, oldWidth;
       $lightbox = $('#lightbox');
       $outerContainer = $lightbox.find('.lb-outerContainer');
       oldWidth = $outerContainer.outerWidth();
@@ -241,14 +217,13 @@ lightbox = new Lightbox options
           height: newHeight
         }, this.options.resizeDuration, 'swing');
       }
-      setTimeout(function() {
+      setTimeout(__bind(function() {
         $lightbox.find('.lb-dataContainer').width(newWidth);
         $lightbox.find('.lb-prevLink').height(newHeight);
         $lightbox.find('.lb-nextLink').height(newHeight);
-        _this.showImage();
-      }, this.options.resizeDuration);
+        this.showImage();
+      }, this), this.options.resizeDuration);
     };
-
     Lightbox.prototype.showImage = function() {
       var $lightbox;
       $lightbox = $('#lightbox');
@@ -259,20 +234,19 @@ lightbox = new Lightbox options
       this.preloadNeighboringImages();
       this.enableKeyboardNav();
     };
-
     Lightbox.prototype.updateNav = function() {
       var $lightbox;
       $lightbox = $('#lightbox');
       $lightbox.find('.lb-nav').show();
-      if (this.currentImageIndex > 0) $lightbox.find('.lb-prev').show();
-      if (this.currentImageIndex < this.album.length - 1) {
-        $lightbox.find('.lb-next').show();
+      if (this.currentImageIndex > 0) {
+        $lightbox.find('.lb-prev').show();
+        if (this.currentImageIndex < this.album.length - 1) {
+          $lightbox.find('.lb-next').show();
+        }
       }
     };
-
     Lightbox.prototype.updateDetails = function() {
-      var $lightbox,
-        _this = this;
+      var $lightbox;
       $lightbox = $('#lightbox');
       if (typeof this.album[this.currentImageIndex].title !== 'undefined' && this.album[this.currentImageIndex].title !== "") {
         $lightbox.find('.lb-caption').html(this.album[this.currentImageIndex].title).fadeIn('fast');
@@ -283,11 +257,8 @@ lightbox = new Lightbox options
         $lightbox.find('.lb-number').hide();
       }
       $lightbox.find('.lb-outerContainer').removeClass('animating');
-      $lightbox.find('.lb-dataContainer').fadeIn(this.resizeDuration, function() {
-        return _this.sizeOverlay();
-      });
+      $lightbox.find('.lb-dataContainer').fadeIn(this.resizeDuration);
     };
-
     Lightbox.prototype.preloadNeighboringImages = function() {
       var preloadNext, preloadPrev;
       if (this.album.length > this.currentImageIndex + 1) {
@@ -299,15 +270,12 @@ lightbox = new Lightbox options
         preloadPrev.src = this.album[this.currentImageIndex - 1].link;
       }
     };
-
     Lightbox.prototype.enableKeyboardNav = function() {
       $(document).on('keyup.keyboard', $.proxy(this.keyboardAction, this));
     };
-
     Lightbox.prototype.disableKeyboardNav = function() {
       $(document).off('.keyboard');
     };
-
     Lightbox.prototype.keyboardAction = function(event) {
       var KEYCODE_ESC, KEYCODE_LEFTARROW, KEYCODE_RIGHTARROW, key, keycode;
       KEYCODE_ESC = 27;
@@ -327,25 +295,19 @@ lightbox = new Lightbox options
         }
       }
     };
-
     Lightbox.prototype.end = function() {
       this.disableKeyboardNav();
-      $(window).off("resize", this.sizeOverlay);
       $('#lightbox').fadeOut(this.options.fadeDuration);
       $('#lightboxOverlay').fadeOut(this.options.fadeDuration);
       return $('select, object, embed').css({
         visibility: "visible"
       });
     };
-
     return Lightbox;
-
   })();
-
   $(function() {
     var lightbox, options;
     options = new LightboxOptions;
     return lightbox = new Lightbox(options);
   });
-
 }).call(this);

--- a/sass/lightbox.sass
+++ b/sass/lightbox.sass
@@ -47,6 +47,11 @@
   width: 100%
   text-align: center
   line-height: 0
+  .lb-cancel
+    background: url("../images/loading.gif")
+    display: inline-block
+    height: 32px
+    width: 32px
 
 .lb-nav
   position: absolute
@@ -111,8 +116,10 @@
     font-size: 11px
   .lb-close
     width: 35px
+    height: 35px
     float: right
     padding-bottom: 0.7em
     outline: none
+    background: url("../images/close.png") no-repeat
     &:hover
       cursor: pointer


### PR DESCRIPTION
The changes result in using CSS only for the overlay so that it stays at the correct position even when scrolling large images. Previously the user could scroll the overlay away.

JavaScript does not longer generate references to images (close button, loading status) but uses CSS classes instead. That allows to exchange the images if desired with the site's CSS and the default images are given relative to the CSS file, too. Therefore Lightbox 2 can now be extracted into any subfolder without the need to have an images folder in the base directory of the page including Lightbox 2.
