### PR TITLE
Removing semicolons as they result in CoffeeScript 1.1.1 messing up the ...

### DIFF
--- a/coffee/lightbox.coffee
+++ b/coffee/lightbox.coffee
@@ -278,8 +278,8 @@ class Lightbox
   updateNav: ->
     $lightbox = $('#lightbox')
     $lightbox.find('.lb-nav').show()
-    if @currentImageIndex > 0 then $lightbox.find('.lb-prev').show();
-    if @currentImageIndex < @album.length - 1 then $lightbox.find('.lb-next').show();
+    if @currentImageIndex > 0 then $lightbox.find('.lb-prev').show()
+    if @currentImageIndex < @album.length - 1 then $lightbox.find('.lb-next').show()
     return
   
   # Display caption, image number, and closing button. 

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -1,52 +1,48 @@
-
-/*
-Lightbox v2.51
-by Lokesh Dhakar - http://www.lokeshdhakar.com
-
-For more information, visit:
-http://lokeshdhakar.com/projects/lightbox2/
-
-Licensed under the Creative Commons Attribution 2.5 License - http://creativecommons.org/licenses/by/2.5/
-- free for use in both personal and commercial projects
-- attribution requires leaving author name, author link, and the license info intact
-	
-Thanks
-- Scott Upton(uptonic.com), Peter-Paul Koch(quirksmode.com), and Thomas Fuchs(mir.aculo.us) for ideas, libs, and snippets.
-- Artemy Tregubenko (arty.name) for cleanup and help in updating to latest proto-aculous in v2.05.
-
-
-Table of Contents
-=================
-LightboxOptions
-
-Lightbox
-- constructor
-- init
-- enable
-- build
-- start
-- changeImage
-- sizeContainer
-- showImage
-- updateNav
-- updateDetails
-- preloadNeigbhoringImages
-- enableKeyboardNav
-- disableKeyboardNav
-- keyboardAction
-- end
-
-options = new LightboxOptions
-lightbox = new Lightbox options
-*/
-
 (function() {
-  var $, Lightbox, LightboxOptions;
-
+  /*
+  Lightbox v2.51
+  by Lokesh Dhakar - http://www.lokeshdhakar.com
+  
+  For more information, visit:
+  http://lokeshdhakar.com/projects/lightbox2/
+  
+  Licensed under the Creative Commons Attribution 2.5 License - http://creativecommons.org/licenses/by/2.5/
+  - free for use in both personal and commercial projects
+  - attribution requires leaving author name, author link, and the license info intact
+  	
+  Thanks
+  - Scott Upton(uptonic.com), Peter-Paul Koch(quirksmode.com), and Thomas Fuchs(mir.aculo.us) for ideas, libs, and snippets.
+  - Artemy Tregubenko (arty.name) for cleanup and help in updating to latest proto-aculous in v2.05.
+  
+  
+  Table of Contents
+  =================
+  LightboxOptions
+  
+  Lightbox
+  - constructor
+  - init
+  - enable
+  - build
+  - start
+  - changeImage
+  - sizeContainer
+  - showImage
+  - updateNav
+  - updateDetails
+  - preloadNeigbhoringImages
+  - enableKeyboardNav
+  - disableKeyboardNav
+  - keyboardAction
+  - end
+  
+  options = new LightboxOptions
+  lightbox = new Lightbox options
+  
+  */  var $, Lightbox, LightboxOptions;
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
   $ = jQuery;
-
   LightboxOptions = (function() {
-
     function LightboxOptions() {
       this.fileLoadingImage = 'images/loading.gif';
       this.fileCloseImage = 'images/close.png';
@@ -55,36 +51,27 @@ lightbox = new Lightbox options
       this.labelImage = "Image";
       this.labelOf = "of";
     }
-
     return LightboxOptions;
-
   })();
-
   Lightbox = (function() {
-
     function Lightbox(options) {
       this.options = options;
       this.album = [];
       this.currentImageIndex = void 0;
       this.init();
     }
-
     Lightbox.prototype.init = function() {
       this.enable();
       return this.build();
     };
-
     Lightbox.prototype.enable = function() {
-      var _this = this;
-      return $('body').on('click', 'a[rel^=lightbox], area[rel^=lightbox]', function(e) {
-        _this.start($(e.currentTarget));
+      return $('body').on('click', 'a[rel^=lightbox], area[rel^=lightbox]', __bind(function(e) {
+        this.start($(e.currentTarget));
         return false;
-      });
+      }, this));
     };
-
     Lightbox.prototype.build = function() {
-      var $lightbox,
-        _this = this;
+      var $lightbox;
       $("<div>", {
         id: 'lightboxOverlay'
       }).after($('<div/>', {
@@ -124,33 +111,36 @@ lightbox = new Lightbox options
       }).append($('<img/>', {
         src: this.options.fileCloseImage
       }))))))).appendTo($('body'));
-      $('#lightboxOverlay').hide().on('click', function(e) {
-        _this.end();
+      $('#lightboxOverlay').hide().on('click', __bind(function(e) {
+        this.end();
         return false;
-      });
+      }, this));
       $lightbox = $('#lightbox');
-      $lightbox.hide().on('click', function(e) {
-        if ($(e.target).attr('id') === 'lightbox') _this.end();
+      $lightbox.hide().on('click', __bind(function(e) {
+        if ($(e.target).attr('id') === 'lightbox') {
+          this.end();
+        }
         return false;
-      });
-      $lightbox.find('.lb-outerContainer').on('click', function(e) {
-        if ($(e.target).attr('id') === 'lightbox') _this.end();
+      }, this));
+      $lightbox.find('.lb-outerContainer').on('click', __bind(function(e) {
+        if ($(e.target).attr('id') === 'lightbox') {
+          this.end();
+        }
         return false;
-      });
-      $lightbox.find('.lb-prev').on('click', function(e) {
-        _this.changeImage(_this.currentImageIndex - 1);
+      }, this));
+      $lightbox.find('.lb-prev').on('click', __bind(function(e) {
+        this.changeImage(this.currentImageIndex - 1);
         return false;
-      });
-      $lightbox.find('.lb-next').on('click', function(e) {
-        _this.changeImage(_this.currentImageIndex + 1);
+      }, this));
+      $lightbox.find('.lb-next').on('click', __bind(function(e) {
+        this.changeImage(this.currentImageIndex + 1);
         return false;
-      });
-      $lightbox.find('.lb-loader, .lb-close').on('click', function(e) {
-        _this.end();
+      }, this));
+      $lightbox.find('.lb-loader, .lb-close').on('click', __bind(function(e) {
+        this.end();
         return false;
-      });
+      }, this));
     };
-
     Lightbox.prototype.start = function($link) {
       var $lightbox, $window, a, i, imageNumber, left, top, _len, _ref;
       $(window).on("resize", this.sizeOverlay);
@@ -173,7 +163,9 @@ lightbox = new Lightbox options
             link: $(a).attr('href'),
             title: $(a).attr('title')
           });
-          if ($(a).attr('href') === $link.attr('href')) imageNumber = i;
+          if ($(a).attr('href') === $link.attr('href')) {
+            imageNumber = i;
+          }
         }
       }
       $window = $(window);
@@ -186,10 +178,8 @@ lightbox = new Lightbox options
       }).fadeIn(this.options.fadeDuration);
       this.changeImage(imageNumber);
     };
-
     Lightbox.prototype.changeImage = function(imageNumber) {
-      var $image, $lightbox, preloader,
-        _this = this;
+      var $image, $lightbox, preloader;
       this.disableKeyboardNav();
       $lightbox = $('#lightbox');
       $image = $lightbox.find('.lb-image');
@@ -199,23 +189,20 @@ lightbox = new Lightbox options
       $lightbox.find('.lb-image, .lb-nav, .lb-prev, .lb-next, .lb-dataContainer, .lb-numbers, .lb-caption').hide();
       $lightbox.find('.lb-outerContainer').addClass('animating');
       preloader = new Image;
-      preloader.onload = function() {
-        $image.attr('src', _this.album[imageNumber].link);
+      preloader.onload = __bind(function() {
+        $image.attr('src', this.album[imageNumber].link);
         $image.width = preloader.width;
         $image.height = preloader.height;
-        return _this.sizeContainer(preloader.width, preloader.height);
-      };
+        return this.sizeContainer(preloader.width, preloader.height);
+      }, this);
       preloader.src = this.album[imageNumber].link;
       this.currentImageIndex = imageNumber;
     };
-
     Lightbox.prototype.sizeOverlay = function() {
       return $('#lightboxOverlay').width($(document).width()).height($(document).height());
     };
-
     Lightbox.prototype.sizeContainer = function(imageWidth, imageHeight) {
-      var $container, $lightbox, $outerContainer, containerBottomPadding, containerLeftPadding, containerRightPadding, containerTopPadding, newHeight, newWidth, oldHeight, oldWidth,
-        _this = this;
+      var $container, $lightbox, $outerContainer, containerBottomPadding, containerLeftPadding, containerRightPadding, containerTopPadding, newHeight, newWidth, oldHeight, oldWidth;
       $lightbox = $('#lightbox');
       $outerContainer = $lightbox.find('.lb-outerContainer');
       oldWidth = $outerContainer.outerWidth();
@@ -241,14 +228,13 @@ lightbox = new Lightbox options
           height: newHeight
         }, this.options.resizeDuration, 'swing');
       }
-      setTimeout(function() {
+      setTimeout(__bind(function() {
         $lightbox.find('.lb-dataContainer').width(newWidth);
         $lightbox.find('.lb-prevLink').height(newHeight);
         $lightbox.find('.lb-nextLink').height(newHeight);
-        _this.showImage();
-      }, this.options.resizeDuration);
+        this.showImage();
+      }, this), this.options.resizeDuration);
     };
-
     Lightbox.prototype.showImage = function() {
       var $lightbox;
       $lightbox = $('#lightbox');
@@ -259,20 +245,19 @@ lightbox = new Lightbox options
       this.preloadNeighboringImages();
       this.enableKeyboardNav();
     };
-
     Lightbox.prototype.updateNav = function() {
       var $lightbox;
       $lightbox = $('#lightbox');
       $lightbox.find('.lb-nav').show();
-      if (this.currentImageIndex > 0) $lightbox.find('.lb-prev').show();
+      if (this.currentImageIndex > 0) {
+        $lightbox.find('.lb-prev').show();
+      }
       if (this.currentImageIndex < this.album.length - 1) {
         $lightbox.find('.lb-next').show();
       }
     };
-
     Lightbox.prototype.updateDetails = function() {
-      var $lightbox,
-        _this = this;
+      var $lightbox;
       $lightbox = $('#lightbox');
       if (typeof this.album[this.currentImageIndex].title !== 'undefined' && this.album[this.currentImageIndex].title !== "") {
         $lightbox.find('.lb-caption').html(this.album[this.currentImageIndex].title).fadeIn('fast');
@@ -283,11 +268,10 @@ lightbox = new Lightbox options
         $lightbox.find('.lb-number').hide();
       }
       $lightbox.find('.lb-outerContainer').removeClass('animating');
-      $lightbox.find('.lb-dataContainer').fadeIn(this.resizeDuration, function() {
-        return _this.sizeOverlay();
-      });
+      $lightbox.find('.lb-dataContainer').fadeIn(this.resizeDuration, __bind(function() {
+        return this.sizeOverlay();
+      }, this));
     };
-
     Lightbox.prototype.preloadNeighboringImages = function() {
       var preloadNext, preloadPrev;
       if (this.album.length > this.currentImageIndex + 1) {
@@ -299,15 +283,12 @@ lightbox = new Lightbox options
         preloadPrev.src = this.album[this.currentImageIndex - 1].link;
       }
     };
-
     Lightbox.prototype.enableKeyboardNav = function() {
       $(document).on('keyup.keyboard', $.proxy(this.keyboardAction, this));
     };
-
     Lightbox.prototype.disableKeyboardNav = function() {
       $(document).off('.keyboard');
     };
-
     Lightbox.prototype.keyboardAction = function(event) {
       var KEYCODE_ESC, KEYCODE_LEFTARROW, KEYCODE_RIGHTARROW, key, keycode;
       KEYCODE_ESC = 27;
@@ -327,7 +308,6 @@ lightbox = new Lightbox options
         }
       }
     };
-
     Lightbox.prototype.end = function() {
       this.disableKeyboardNav();
       $(window).off("resize", this.sizeOverlay);
@@ -337,15 +317,11 @@ lightbox = new Lightbox options
         visibility: "visible"
       });
     };
-
     return Lightbox;
-
   })();
-
   $(function() {
     var lightbox, options;
     options = new LightboxOptions;
     return lightbox = new Lightbox(options);
   });
-
 }).call(this);


### PR DESCRIPTION
...blocks of following if statements

As a result you cannot navigate from the first image in an album to the second image.
Current versions of CoffeeScript generate the same/correct output regardless if the semicolons are there or not. I think its better to remove them because not putting the semicolons make the Lightbox 2 code more consistent and allows using older CoffeeScript versions.
