### PR TITLE
HTML5 compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,10 +49,10 @@
 	<h3>Single image</h3>
   <div class="imageRow">
   	<div class="single">
-  		<a href="images/examples/image-1.jpg" rel="lightbox"><img src="images/examples/thumb-1.jpg" alt="" /></a>
+  		<a href="images/examples/image-1.jpg" data-lightbox><img src="images/examples/thumb-1.jpg" alt="" /></a>
   	</div>
   	<div class="single">
-  		<a href="images/examples/image-2.jpg" rel="lightbox" title="Optional caption."><img src="images/examples/thumb-2.jpg" alt="" /></a>
+  		<a href="images/examples/image-2.jpg" data-lightbox title="Optional caption."><img src="images/examples/thumb-2.jpg" alt="" /></a>
   	</div>
   </div>
 
@@ -61,16 +61,16 @@
   <div class="imageRow">
   	<div class="set">
   	  <div class="single first">
-  		  <a href="images/examples/image-3.jpg" rel="lightbox[plants]" title="Click on the right side of the image to move forward."><img src="images/examples/thumb-3.jpg" alt="Plants: image 1 0f 4 thumb" /></a>
+  		  <a href="images/examples/image-3.jpg" data-lightbox data-lightbox-group="plants" title="Click on the right side of the image to move forward."><img src="images/examples/thumb-3.jpg" alt="Plants: image 1 0f 4 thumb" /></a>
   		</div>
       <div class="single">
-  		  <a href="images/examples/image-4.jpg" rel="lightbox[plants]" title="Alternately you can press the right arrow key." ><img src="images/examples/thumb-4.jpg" alt="Plants: image 2 0f 4 thumb" /></a>
+  		  <a href="images/examples/image-4.jpg" data-lightbox data-lightbox-group="plants" title="Alternately you can press the right arrow key." ><img src="images/examples/thumb-4.jpg" alt="Plants: image 2 0f 4 thumb" /></a>
       </div>
       <div class="single">
-  		  <a href="images/examples/image-5.jpg" rel="lightbox[plants]" title="The script preloads the next image in the set as you're viewing."><img src="images/examples/thumb-5.jpg" alt="Plants: image 3 0f 4 thumb" /></a>
+  		  <a href="images/examples/image-5.jpg" data-lightbox data-lightbox-group="plants" title="The script preloads the next image in the set as you're viewing."><img src="images/examples/thumb-5.jpg" alt="Plants: image 3 0f 4 thumb" /></a>
       </div>
       <div class="single last">
-  		  <a href="images/examples/image-6.jpg" rel="lightbox[plants]" title="Click the X or anywhere outside the image to close"><img src="images/examples/thumb-6.jpg" alt="Plants: image 4 0f 4 thumb" /></a>
+  		  <a href="images/examples/image-6.jpg" data-lightbox data-lightbox-group="plants" title="Click the X or anywhere outside the image to close"><img src="images/examples/thumb-6.jpg" alt="Plants: image 4 0f 4 thumb" /></a>
       </div>
   	</div>
   </div>
@@ -153,14 +153,14 @@
 	</ol>
 	<h3>Part 2 - Activate</h3>
 	<ol>
-		<li>Add a <code>rel="lightbox"</code> attribute to any link tag to activate Lightbox.
-<pre><code>&lt;a href=&quot;images/image-1.jpg&quot; rel=&quot;lightbox&quot; title=&quot;my caption&quot;&gt;image #1&lt;/a&gt;
+		<li>Add a <code>data-lightbox</code> attribute to any link tag to activate Lightbox.
+<pre><code>&lt;a href=&quot;images/image-1.jpg&quot; data-lightbox title=&quot;my caption&quot;&gt;image #1&lt;/a&gt;
 </code></pre>
 		<em>Optional: </em>Use the <code>title</code> attribute if you want to show a caption.		</li>
-		<li>If you have a set of related images that you would like to group, follow step one but additionally include a group name between square brackets in the rel attribute. 
-<pre><code>&lt;a href=&quot;images/image-1.jpg&quot; rel=&quot;lightbox[roadtrip]&quot;&gt;image #1&lt;/a&gt;
-&lt;a href=&quot;images/image-2.jpg&quot; rel=&quot;lightbox[roadtrip]&quot;&gt;image #2&lt;/a&gt;
-&lt;a href=&quot;images/image-3.jpg&quot; rel=&quot;lightbox[roadtrip]&quot;&gt;image #3&lt;/a&gt;
+		<li>If you have a set of related images that you would like to group, follow step one but additionally include a group name as <code>data-lightbox-group</code> attribute. 
+<pre><code>&lt;a href=&quot;images/image-1.jpg&quot; data-lightbox data-lightbox-group=&quot;roadtrip&quot;&gt;image #1&lt;/a&gt;
+&lt;a href=&quot;images/image-2.jpg&quot; data-lightbox data-lightbox-group=&quot;roadtrip&quot;&gt;image #2&lt;/a&gt;
+&lt;a href=&quot;images/image-3.jpg&quot; data-lightbox data-lightbox-group=&quot;roadtrip&quot;&gt;image #3&lt;/a&gt;
 </code></pre>
 	No limits to the number of image sets per page or how many images are allowed in each set. Go nuts!</li>
 	</ol>	

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -76,7 +76,7 @@ lightbox = new Lightbox options
 
     Lightbox.prototype.enable = function() {
       var _this = this;
-      return $('body').on('click', 'a[rel^=lightbox], area[rel^=lightbox]', function(e) {
+      return $('body').on('click', 'a[data-lightbox], area[data-lightbox]', function(e) {
         _this.start($(e.currentTarget));
         return false;
       });
@@ -160,13 +160,13 @@ lightbox = new Lightbox options
       $('#lightboxOverlay').width($(document).width()).height($(document).height()).fadeIn(this.options.fadeDuration);
       this.album = [];
       imageNumber = 0;
-      if ($link.attr('rel') === 'lightbox') {
+      if ($link.attr('data-lightbox-group') == undefined) {
         this.album.push({
           link: $link.attr('href'),
           title: $link.attr('title')
         });
       } else {
-        _ref = $($link.prop("tagName") + '[rel="' + $link.attr('rel') + '"]');
+        _ref = $($link.prop("tagName") + '[data-lightbox-group="' + $link.attr('data-lightbox-group') + '"]');
         for (i = 0, _len = _ref.length; i < _len; i++) {
           a = _ref[i];
           this.album.push({


### PR DESCRIPTION
Hi Lokesh,

the current version of lightbox2 using "rel" attribute is not valid in HTML5 context. [1]

I created a version which is valid for HTML5, but not for older standards. The only possibility I see to be compatible with HTML5 and older standards would be to make the attribute configurable, which seems to be too complex to handle for a user, which just wants to include the lightbox script.

Best regards
Adrian

[1] http://validator.w3.org/check?uri=http%3A%2F%2Flokeshdhakar.com%2Fprojects%2Flightbox2%2F&charset=%28detect+automatically%29&doctype=Inline&group=0
