### PR TITLE
fix bug: the loader image disappeared when the image changed

### DIFF
--- a/coffee/lightbox.coffee
+++ b/coffee/lightbox.coffee
@@ -159,7 +159,7 @@ class Lightbox
     @sizeOverlay()
     $('#lightboxOverlay').fadeIn( @options.fadeDuration )
     
-    $('.loader').fadeIn 'slow'
+    $('.lb-loader').fadeIn 'slow'
     $lightbox.find('.lb-image, .lb-nav, .lb-prev, .lb-next, .lb-dataContainer, .lb-numbers, .lb-caption').hide()
 
     $lightbox.find('.lb-outerContainer').addClass 'animating'

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -165,7 +165,7 @@ lightbox = new Lightbox options
       $image = $lightbox.find('.lb-image');
       this.sizeOverlay();
       $('#lightboxOverlay').fadeIn(this.options.fadeDuration);
-      $('.loader').fadeIn('slow');
+      $('.lb-loader').fadeIn('slow');
       $lightbox.find('.lb-image, .lb-nav, .lb-prev, .lb-next, .lb-dataContainer, .lb-numbers, .lb-caption').hide();
       $lightbox.find('.lb-outerContainer').addClass('animating');
       preloader = new Image;


### PR DESCRIPTION
fix bug: the loader image disappeared when navigating the image.
change loader selector from $('.loader') to correct $('.lb-loader')
