### PR TITLE
Fit images in viewport is limited to horizontal viewport size FIX

### DIFF
--- a/coffee/lightbox.coffee
+++ b/coffee/lightbox.coffee
@@ -193,24 +193,29 @@ class Lightbox
       
       $preloader = $(preloader)
 
+      $image.width preloader.width
+      $image.height preloader.height
+
       if @options.fitImagesInViewport
         # Fit image inside the viewport.
         # Take into account the border around the image and an additional 10px gutter on each side.
         windowWidth   = $(window).width()
+        windowHeight  = $(window).height()
         maxImageWidth = windowWidth - @containerLeftPadding - @containerRightPadding - 20
-
-        if preloader.width > maxImageWidth
-          imageWidth = maxImageWidth
-          imageHeight = parseInt (preloader.height / (preloader.width/imageWidth)), 10
-          $image.width imageWidth
-          $image.height imageHeight
-        else 
-          $image.width preloader.width
-          $image.height preloader.height
-
-      else 
-        $image.width preloader.width
-        $image.height preloader.height
+        maxImageHeight = windowHeight - @containerTopPadding - @containerBottomPadding - 200
+        # Is there a fitting issue at all?
+        if (preloader.width > maxImageWidth) || (preloader.height > maxImageHeight)
+          # Use the highest scaling factor to determine which side of the image the scaling is based on
+          if (preloader.width / maxImageWidth) > (preloader.height / maxImageHeight)
+            imageWidth = maxImageWidth
+            imageHeight = parseInt (preloader.height / (preloader.width/imageWidth)), 10
+            $image.width imageWidth
+            $image.height imageHeight
+          else
+            imageHeight = maxImageHeight
+            imageWidth = parseInt (preloader.width / (preloader.height/imageHeight)), 10
+            $image.width imageWidth
+            $image.height imageHeight
 
       @sizeContainer $image.width(), $image.height()
 

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -195,24 +195,29 @@ lightbox = new Lightbox options
       this.$outerContainer.addClass('animating');
       preloader = new Image();
       preloader.onload = function() {
-        var $preloader, imageHeight, imageWidth, maxImageWidth, windowWidth;
+        var $preloader, imageHeight, imageWidth, maxImageHeight, maxImageWidth, windowHeight, windowWidth;
         $image.attr('src', _this.album[imageNumber].link);
         $preloader = $(preloader);
+        $image.width(preloader.width);
+        $image.height(preloader.height);
         if (_this.options.fitImagesInViewport) {
           windowWidth = $(window).width();
+          windowHeight = $(window).height();
           maxImageWidth = windowWidth - _this.containerLeftPadding - _this.containerRightPadding - 20;
-          if (preloader.width > maxImageWidth) {
-            imageWidth = maxImageWidth;
-            imageHeight = parseInt(preloader.height / (preloader.width / imageWidth), 10);
-            $image.width(imageWidth);
-            $image.height(imageHeight);
-          } else {
-            $image.width(preloader.width);
-            $image.height(preloader.height);
+          maxImageHeight = windowHeight - _this.containerTopPadding - _this.containerBottomPadding - 200;
+          if ((preloader.width > maxImageWidth) || (preloader.height > maxImageHeight)) {
+            if ((preloader.width / maxImageWidth) > (preloader.height / maxImageHeight)) {
+              imageWidth = maxImageWidth;
+              imageHeight = parseInt(preloader.height / (preloader.width / imageWidth), 10);
+              $image.width(imageWidth);
+              $image.height(imageHeight);
+            } else {
+              imageHeight = maxImageHeight;
+              imageWidth = parseInt(preloader.width / (preloader.height / imageHeight), 10);
+              $image.width(imageWidth);
+              $image.height(imageHeight);
+            }
           }
-        } else {
-          $image.width(preloader.width);
-          $image.height(preloader.height);
         }
         return _this.sizeContainer($image.width(), $image.height());
       };


### PR DESCRIPTION
Yesterday I submitted an issue: https://github.com/lokesh/lightbox2/issues/48.
The fix code I added in that issue was mathematically incorrect, something I realised today. I Googled it and used http://stackoverflow.com/a/1106367/368102 to fix it. And while I was at it I thought I might as well do it properly and fix it in the Coffeescript in a Github fork.
So here is the pull request to pull it in if you like. If not, feel free to ignore it.
I will close the issue now with a link to this pull request.

Git commit comment: 
So far the fit to viewport only scaled the image if it was wider than the viewport and not if it was higher.
This fix will scale the image if it is either wider, higher, or both than the viewport, based on which scaling factor is larger (see this Stackoverflow question: http://stackoverflow.com/a/1106367/368102).
