### PR TITLE
Added Bundler-support and compass-commands.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'compass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    chunky_png (1.2.8)
+    compass (0.12.2)
+      chunky_png (~> 1.2)
+      fssm (>= 0.2.7)
+      sass (~> 3.1)
+    fssm (0.2.10)
+    sass (3.2.9)
+
+PLATFORMS
+  x86-mingw32
+
+DEPENDENCIES
+  compass

--- a/config.rb
+++ b/config.rb
@@ -1,0 +1,19 @@
+# Require any additional compass plugins here.
+
+# Set this to the root of your project when deployed:
+http_path = "/"
+css_dir = "css"
+sass_dir = "sass"
+images_dir = "img"
+javascripts_dir = "js"
+
+# You can select your preferred output style here (can be overridden via the command line):
+# output_style = :expanded or :nested or :compact or :compressed
+
+# To enable relative paths to assets via compass helper functions. Uncomment:
+relative_assets = true
+
+# To disable debugging comments that display the original location of your selectors. Uncomment:
+# line_comments = false
+
+preferred_syntax = :sass

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "scripts": {
     "build": "coffee --compile --output ./js/ ./coffee/",
     "check": "jshint ./js/lightbox.js",
-    "lint": "jshint ./js/lightbox.js"
+    "lint": "jshint ./js/lightbox.js",
+    "install-compass": "bundle install",
+    "update-compass": "bundle update",
+    "build-compass": "bundle exec compass compile"
   },
   "licenses": [
     {


### PR DESCRIPTION
So this adds support for [Bundler](https://rubygems.org/gems/bundler) and expands `package.json`to include three new commands:
- `npm run compass-install`: Installs compass and dependencies, if ruby and bundler are present
- `npm run compass-update`: Update Gemfile.lock to reference newer versions
- `npm run compass-build`: Convert the sass-files to css-files

Why compass-build? Right now Windows does not support ";" to seperate commands in script-statements and I would like to be able to run theses commands on my windows machine.

We should consider the hint of using a `.gyp` file as build-script as presented on https://npmjs.org/doc/scripts.html
