### PR TITLE
Improved: correct overlay width

### DIFF
--- a/coffee/lightbox.coffee
+++ b/coffee/lightbox.coffee
@@ -108,7 +108,7 @@ class Lightbox
 
     $('select, object, embed').css visibility: "hidden"
     @$overlay
-      .width( $(document).width())
+      .width('100%')
       .height( $(document).height() )
       .fadeIn( @options.fadeDuration )
 
@@ -203,7 +203,7 @@ class Lightbox
   # Stretch overlay to fit the document
   sizeOverlay: () ->
     $('#lightboxOverlay')
-      .width($(document).width())
+      .width('100%')
       .height($(document).height())
 
 


### PR DESCRIPTION
This measure prevents the appearance of horizontal scroll on the high images (greater than the height of the screen)