### PR TITLE
Relative width/height .lb-outerContainer

### DIFF
--- a/css/lightbox.css
+++ b/css/lightbox.css
@@ -47,8 +47,8 @@ body:after {
   position: relative;
   background-color: white;
   *zoom: 1;
-  width: 250px;
-  height: 250px;
+  width: 100%;
+  height: 100%;
   margin: 0 auto;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;


### PR DESCRIPTION
.lb-outerContainers width and height should be set to 100% instead of 250px, which makes lightbox 2 images look like thumbnails.
