### PR TITLE
Fix for Lightbox not taking width of image

### DIFF
--- a/css/lightbox.css
+++ b/css/lightbox.css
@@ -47,8 +47,6 @@ body:after {
   position: relative;
   background-color: white;
   *zoom: 1;
-  width: 250px;
-  height: 250px;
   margin: 0 auto;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;


### PR DESCRIPTION
I some cases with the new jQeury in combination with Bootstrap the width of Lightbox is not setting according to width from the image.
