### PR TITLE
Update lightbox.coffee

### DIFF
--- a/coffee/lightbox.coffee
+++ b/coffee/lightbox.coffee
@@ -119,17 +119,17 @@ class Lightbox
     dataLightboxValue = $link.attr 'data-lightbox'
     if dataLightboxValue
       for a, i in $( $link.prop("tagName") + '[data-lightbox="' + dataLightboxValue + '"]')
-        @album.push link: $(a).attr('href'), title: $(a).attr('title')
+        @album.push link: $(a).attr('href'), title: $(a).attr('title') || $(a).children('img').first().attr('alt')
         if $(a).attr('href') == $link.attr('href')
           imageNumber = i
     else 
       if $link.attr('rel') == 'lightbox'
         # If image is not part of a set
-        @album.push link: $link.attr('href'), title: $link.attr('title')
+        @album.push link: $link.attr('href'), title: $link.attr('title') || $link.children('img').first().attr('alt')
       else
         # Image is part of a set
         for a, i in $( $link.prop("tagName") + '[rel="' + $link.attr('rel') + '"]')
-          @album.push link: $(a).attr('href'), title: $(a).attr('title')
+          @album.push link: $(a).attr('href'), title: $(a).attr('title') || $(a).children('img').first().attr('alt')
           if $(a).attr('href') == $link.attr('href')
             imageNumber = i
 


### PR DESCRIPTION
If a link has not "title" attribute, use the natural "alt" attribute of its first child.
This is more semantic and avoids doublon between the attributes "title" and "alt".
Furthermore, navigators display the "title" attributes.
