### PR TITLE
Fix for keyboard navigation, when wrapAround is used.

### DIFF
--- a/coffee/lightbox.coffee
+++ b/coffee/lightbox.coffee
@@ -313,12 +313,12 @@ class Lightbox
     else if key == 'p' || keycode == KEYCODE_LEFTARROW
       if @currentImageIndex != 0
           @changeImage @currentImageIndex - 1
-      else if @options.wrapAround
+      else if @options.wrapAround && @album.length > 1
           @changeImage @album.length - 1
     else if key == 'n' || keycode == KEYCODE_RIGHTARROW
       if @currentImageIndex != @album.length - 1
           @changeImage @currentImageIndex + 1
-      else if @options.wrapAround
+      else if @options.wrapAround && @album.length > 1
           @changeImage 0
     return
 


### PR DESCRIPTION
Wrap around option is working only for mouse navigation. This fix allows to wrap with keyboard next/prev keys when first/last image is active.
