### PR TITLE
Compatibility with turbolinks

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -49,7 +49,9 @@ Licensed under the Creative Commons Attribution 2.5 License - http://creativecom
 
     Lightbox.prototype.enable = function() {
       var _this = this;
-      return $('body').on('click', 'a[rel^=lightbox], area[rel^=lightbox], a[data-lightbox], area[data-lightbox]', function(e) {
+      return $(document).on('click', 'a[rel^=lightbox], area[rel^=lightbox], a[data-lightbox], area[data-lightbox]', function(e) {
+        _this.$overlay.appendTo('body');
+        _this.$lightbox.appendTo('body');
         _this.start($(e.currentTarget));
         return false;
       });


### PR DESCRIPTION
I was having trouble with lightbox when combined to a page loaded using turbolinks: it wouldn't work.
For this to work, the event is now delegated to `document` instead of `'body'` and we re-append the overlay and the lightbox container on each click.

Note: i didn't change the .min.js file
