### PR TITLE
correct display images in original/normal size

### DIFF
--- a/css/lightbox.css
+++ b/css/lightbox.css
@@ -47,8 +47,8 @@ body:after {
   position: relative;
   background-color: white;
   *zoom: 1;
-  width: 250px;
-  height: 250px;
+  width: auto;
+  height: auto;
   margin: 0 auto;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;


### PR DESCRIPTION
.lb-outerContainer {
  position: relative;
  background-color: white;
  _zoom: 1;
    width: auto;
    height: auto;
  /_width: 250px;
  height: 250px;*/
  margin: 0 auto;
  -webkit-border-radius: 4px;
  -moz-border-radius: 4px;
  -ms-border-radius: 4px;
  -o-border-radius: 4px;
  border-radius: 4px;
}
