### PR TITLE
Fix image container resizing

### DIFF
--- a/coffee/lightbox.coffee
+++ b/coffee/lightbox.coffee
@@ -168,8 +168,8 @@ class Lightbox
       
       $preloader = $(preloader)
 
-      $image.width preloader.width
-      $image.height preloader.height
+      imageWidth  = preloader.width
+      imageHeight = preloader.height
 
       if @options.fitImagesInViewport
         # Fit image inside the viewport.
@@ -180,20 +180,19 @@ class Lightbox
         maxImageHeight = windowHeight - @containerTopPadding - @containerBottomPadding - 110
         
         # Is there a fitting issue at all?
-        if (preloader.width > maxImageWidth) || (preloader.height > maxImageHeight)
+        if (imageWidth > maxImageWidth) || (imageHeight > maxImageHeight)
           # Use the highest scaling factor to determine which side of the image the scaling is based on
-          if (preloader.width / maxImageWidth) > (preloader.height / maxImageHeight)
+          if (imageWidth / maxImageWidth) > (imageHeight / maxImageHeight)
             imageWidth  = maxImageWidth
-            imageHeight = parseInt (preloader.height / (preloader.width / imageWidth)), 10
-            $image.width imageWidth
-            $image.height imageHeight
+            imageHeight = parseInt (preloader.height / (preloader.width / maxImageWidth)), 10
           else
             imageHeight = maxImageHeight
-            imageWidth  = parseInt (preloader.width / (preloader.height / imageHeight)), 10
-            $image.width imageWidth
-            $image.height imageHeight
+            imageWidth  = parseInt (preloader.width / (preloader.height / maxImageHeight)), 10
 
-      @sizeContainer $image.width(), $image.height()
+      $image.width imageWidth
+      $image.height imageHeight
+
+      @sizeContainer imageWidth, imageHeight
 
     preloader.src = @album[imageNumber].link
     @currentImageIndex = imageNumber

--- a/coffee/lightbox.coffee
+++ b/coffee/lightbox.coffee
@@ -135,7 +135,7 @@ class Lightbox
 
     # Position lightbox
     $window = $(window)
-    top     = $window.scrollTop() + $window.height()/10
+    top     = $window.scrollTop() + $window.height() / 10
     left    = $window.scrollLeft()
     @$lightbox
       .css
@@ -184,12 +184,12 @@ class Lightbox
           # Use the highest scaling factor to determine which side of the image the scaling is based on
           if (preloader.width / maxImageWidth) > (preloader.height / maxImageHeight)
             imageWidth  = maxImageWidth
-            imageHeight = parseInt (preloader.height / (preloader.width/imageWidth)), 10
+            imageHeight = parseInt (preloader.height / (preloader.width / imageWidth)), 10
             $image.width imageWidth
             $image.height imageHeight
           else
             imageHeight = maxImageHeight
-            imageWidth  = parseInt (preloader.width / (preloader.height/imageHeight)), 10
+            imageWidth  = parseInt (preloader.width / (preloader.height / imageHeight)), 10
             $image.width imageWidth
             $image.height imageHeight
 

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -171,28 +171,26 @@ Licensed under the Creative Commons Attribution 2.5 License - http://creativecom
         var $preloader, imageHeight, imageWidth, maxImageHeight, maxImageWidth, windowHeight, windowWidth;
         $image.attr('src', _this.album[imageNumber].link);
         $preloader = $(preloader);
-        $image.width(preloader.width);
-        $image.height(preloader.height);
+        imageWidth = preloader.width;
+        imageHeight = preloader.height;
         if (_this.options.fitImagesInViewport) {
           windowWidth = $(window).width();
           windowHeight = $(window).height();
           maxImageWidth = windowWidth - _this.containerLeftPadding - _this.containerRightPadding - 20;
           maxImageHeight = windowHeight - _this.containerTopPadding - _this.containerBottomPadding - 110;
-          if ((preloader.width > maxImageWidth) || (preloader.height > maxImageHeight)) {
-            if ((preloader.width / maxImageWidth) > (preloader.height / maxImageHeight)) {
+          if ((imageWidth > maxImageWidth) || (imageHeight > maxImageHeight)) {
+            if ((imageWidth / maxImageWidth) > (imageHeight / maxImageHeight)) {
               imageWidth = maxImageWidth;
-              imageHeight = parseInt(preloader.height / (preloader.width / imageWidth), 10);
-              $image.width(imageWidth);
-              $image.height(imageHeight);
+              imageHeight = parseInt(preloader.height / (preloader.width / maxImageWidth), 10);
             } else {
               imageHeight = maxImageHeight;
-              imageWidth = parseInt(preloader.width / (preloader.height / imageHeight), 10);
-              $image.width(imageWidth);
-              $image.height(imageHeight);
+              imageWidth = parseInt(preloader.width / (preloader.height / maxImageHeight), 10);
             }
           }
         }
-        return _this.sizeContainer($image.width(), $image.height());
+        $image.width(imageWidth);
+        $image.height(imageHeight);
+        return _this.sizeContainer(imageWidth, imageHeight);
       };
       preloader.src = this.album[imageNumber].link;
       this.currentImageIndex = imageNumber;


### PR DESCRIPTION
When an image is resized to fit in the viewport, it lost the original image aspect ratio.
This is because once it is resized, the wrong width and height was being passed to `@sizeContainer(..)`.

Namely, in `@changeImage`, the final width / height passed to `@sizeContainer` was pulled from `$image.width()` and `$image.height()`.
jQuery is oversmart (why is it used at all?), it calculates the real image size that is going to displayed on screen, not the one that we just set using `$image.width(..)` two lines earlier, and the real image size is set by the container size.. that we are about to resize.
So no resizing of the compressed dimension takes place and the image is distorted.

Before patch:
![before](https://f.cloud.github.com/assets/341374/1804845/95c7341e-6c68-11e3-81af-f100eb37cace.png)

After patch:
![after](https://f.cloud.github.com/assets/341374/1804851/dde10f0e-6c68-11e3-8721-2db3048fb7a9.png)
