### PR TITLE
Exclude development and demo assets from bower component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,12 +15,21 @@
     "images"
   ],
   "license": "CC BY 2.5",
+  "dependencies": {
+    "jquery": "~2.1.1"
+  },
   "ignore": [
     "**/.*",
     "Gruntfile.js",
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "releases",
+    "sass",
+    "js/jquery*",
+    "img/demopage",
+    "package.json",
+    "index.html"
   ]
 }


### PR DESCRIPTION
I think this would make it a bit cleaner as bower component. Right now it pulls ~8.5MB and most of it is previous releases and things needed only while developing or viewing a demo page.

Not sure about jQuery version, Lightbox includes 1.x, but I don't know if it's intentional