### PR TITLE
Added ability to manually create and configure Lightbox objects

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -10,34 +10,31 @@
 (function() {
   // Use local alias
   var $ = jQuery;
-
-  var LightboxOptions = (function() {
-    function LightboxOptions() {
-      this.fadeDuration                = 500;
-      this.fitImagesInViewport         = true;
-      this.resizeDuration              = 700;
-      this.positionFromTop             = 50;
-      this.showImageNumberLabel        = true;
-      this.alwaysShowNavOnTouchDevices = false;
-      this.wrapAround                  = false;
-    }
     
-    // Change to localize to non-english language
-    LightboxOptions.prototype.albumLabel = function(curImageNum, albumSize) {
-      return "Image " + curImageNum + " of " + albumSize;
+  window.Lightbox = (function () {
+    var defaultOptions = {
+      fadeDuration: 500,
+      fitImagesInViewport: true,
+      resizeDuration: 700,
+      positionFromTop: 50,
+      showImageNumberLabel: true,
+      alwaysShowNavOnTouchDevices: false,
+      wrapAround: false,
+      albumLabel: function (curImageNum, albumSize) {
+        return "Image " + curImageNum + " of " + albumSize;
+      }
     };
 
-    return LightboxOptions;
-  })();
-
-
-  var Lightbox = (function() {
     function Lightbox(options) {
-      this.options           = options;
+      this.options           = $.extend({}, defaultOptions, options);
       this.album             = [];
       this.currentImageIndex = void 0;
       this.init();
     }
+
+    Lightbox.setDefaultOptions = function (options) {
+      $.extend(defaultOptions, options);
+    };
 
     Lightbox.prototype.init = function() {
       this.enable();
@@ -402,10 +399,5 @@
     return Lightbox;
 
   })();
-
-  $(function() {
-    var options  = new LightboxOptions();
-    var lightbox = new Lightbox(options);
-  });
-
+    
 }).call(this);


### PR DESCRIPTION
I used Lightbox in my project and found that to change its options you must change script source code. Which is not good if you plan to update it or have different options (for different pages or different clients). So I made this fix and ask you to include it into your code. Note that it has small incompatibility with older version, because Lightbox object is no more created in .js script, now the user must manually create it when the page loads. You may need to update the documentation if you accept this.

Changes
LIghtbox is now accessible from the global namespace. 
Removed automatic Lightbox initialization from script file. Now the user must explicitly create a lightbox to activate it.
The minimal code to create lightbox is:
```
$(function() {
  new Lightbox();
}
```
You can also specify options in Lightbox constructor:
```
$(function() {
  new Lightbox({ fadeDuration: 0, resizeDuration: 0 });
}
```
or you can change default options for all lightboxes (put this to page template or some script that is executed on every page):
```
Lightbox.setDefaultOptions({fadeDuration: 0, resizeDuration: 0});
```