### PR TITLE
Allow other elements to start the gallery

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -52,6 +52,11 @@
         self.start($(event.currentTarget));
         return false;
       });
+      $('body').on('click', '*[data-lightbox-label-for]', function(event) {
+        var lightboxElement = $(event.currentTarget).data('lightboxLabelFor');
+        self.start($("#" + lightboxElement));
+        return false;
+      });
     };
 
     // Build html for the lightbox and the overlay.


### PR DESCRIPTION
Allow other elements to start Lightbox on behalf of other elements.
It allows them to act as a sort of <label> for another element that
actually contains the data-lightbox attribute.

The way it works is: you specify the data-lightbox-label-for
attribute for an element. The value of that attribute is the HTML
id of a link that contains a data-lightbox attribute of a rel
attribute containing "lightbox".
