### PR TITLE
Added GPU Acceleration in appropriate area

### DIFF
--- a/css/lightbox.css
+++ b/css/lightbox.css
@@ -4,6 +4,26 @@ body:after {
   display: none;
 }
 
+
+.lightboxOverlay,.lightbox {
+
+  -webkit-backface-visibility:hidden;
+  -moz-backface-visibility:hidden;
+  -ms-backface-visibility:hidden;
+  -o-backface-visibility:hidden;
+  backface-visibility:hidden;
+  -webkit-transform: translateZ(0);
+  -moz-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  -o-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-perspective:1000;
+  -moz-perspective:1000;
+  -ms-perspective:1000;
+  -o-perspective:1000;
+  perspective:1000;  
+}
+
 .lightboxOverlay {
   position: absolute;
   top: 0;
@@ -13,6 +33,8 @@ body:after {
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=80);
   opacity: 0.8;
   display: none;
+
+    
 }
 
 .lightbox {


### PR DESCRIPTION
I've added a translateZ to shift the overlay and lightbox off the main layer on their own compositing layer, added a `3d perspective` (this helps minimize some browsers from janking momentarily on opacity changes) and set the backface to hidden (this will disable some of the GPU intensive stuff that `3d perspective` items have but telling it to only show the front face).

all of this should help to minimize the effects of layout thrashing (also known as jank).
