### PR TITLE
Removed empty src attribute from img tag. Fixes #276

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -58,7 +58,7 @@
     // Attach event handlers to the new DOM elements. click click click
     Lightbox.prototype.build = function() {
       var self = this;
-      $("<div id='lightboxOverlay' class='lightboxOverlay'></div><div id='lightbox' class='lightbox'><div class='lb-outerContainer'><div class='lb-container'><img class='lb-image' src='' /><div class='lb-nav'><a class='lb-prev' href='' ></a><a class='lb-next' href='' ></a></div><div class='lb-loader'><a class='lb-cancel'></a></div></div></div><div class='lb-dataContainer'><div class='lb-data'><div class='lb-details'><span class='lb-caption'></span><span class='lb-number'></span></div><div class='lb-closeContainer'><a class='lb-close'></a></div></div></div></div>").appendTo($('body'));
+      $("<div id='lightboxOverlay' class='lightboxOverlay'></div><div id='lightbox' class='lightbox'><div class='lb-outerContainer'><div class='lb-container'><img class='lb-image' /><div class='lb-nav'><a class='lb-prev' href='' ></a><a class='lb-next' href='' ></a></div><div class='lb-loader'><a class='lb-cancel'></a></div></div></div><div class='lb-dataContainer'><div class='lb-data'><div class='lb-details'><span class='lb-caption'></span><span class='lb-number'></span></div><div class='lb-closeContainer'><a class='lb-close'></a></div></div></div></div>").appendTo($('body'));
       
       // Cache jQuery objects
       this.$lightbox       = $('#lightbox');


### PR DESCRIPTION
The empty src attribute triggers strange behavior in IE 8 and is a bad practice in general.
If lightbox is used on http://example.com/product/123 IE 8 makes a request to http://example.com/product/ to fetch the image. This caused Exceptions invisible in the browser that we needed half a day to track down.
Chrome and Safari (at least in older versions) try to load the image from http://example.com/product/123, so this can double the traffic on your website in the worst case.
See also http://www.nczonline.net/blog/2009/11/30/empty-image-src-can-destroy-your-site/
