### PR TITLE
Fix: Enable target attribute in caption links

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -327,7 +327,11 @@
           .html(this.album[this.currentImageIndex].title)
           .fadeIn('fast')
           .find('a').on('click', function(event){
-            location.href = $(this).attr('href');
+          	if ($(this).attr('target') !== undefined) {
+          	  window.open($(this).attr('href'), $(this).attr('target'));
+          	} else {
+	          location.href = $(this).attr('href');
+	        }
           });
       }
     


### PR DESCRIPTION
With this fix it's possible to open caption links in a new tab/window with target="_blank"