### PR TITLE
Clear the jquery animation queue before hiding the .lb-loader

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -271,7 +271,7 @@
 
     // Display the image and it's details and begin preload neighboring images.
     Lightbox.prototype.showImage = function() {
-      this.$lightbox.find('.lb-loader').hide();
+      this.$lightbox.find('.lb-loader').stop(true).hide();
       this.$lightbox.find('.lb-image').fadeIn('slow');
     
       this.updateNav();


### PR DESCRIPTION
The loader was staying visible when changing images rapidly.

http://jsfiddle.net/d8nL7qy7/  - rapidly click the ">" till the end and you will see the problem.