### PR TITLE
Added an EXIF data field (HTML5 compatible)

### DIFF
--- a/css/lightbox.css
+++ b/css/lightbox.css
@@ -179,6 +179,13 @@ body:after {
   line-height: 1em;
 }
 
+.lb-data .lb-exif {
+  display: block;
+  clear: left;
+  font-size: 13px;
+  color: #999999;
+}
+
 .lb-data .lb-number {
   display: block;
   clear: left;

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 					<div class="image-set">
 						<a class="example-image-link" href="img/demopage/image-3.jpg" data-lightbox="example-set" data-title="Click the right half of the image to move forward." data-exif="Nikon D5100 | f/8.0 | 1/400 | ISO 200"><img class="example-image" src="img/demopage/thumb-3.jpg" alt=""/></a>
 						<a class="example-image-link" href="img/demopage/image-4.jpg" data-lightbox="example-set" data-title="Or press the right arrow on your keyboard." data-exif="Nikon D300 | f/22.0 | 1/20 | ISO 200"><img class="example-image" src="img/demopage/thumb-4.jpg" alt="" /></a>
-						<a class="example-image-link" href="img/demopage/image-5.jpg" data-lightbox="example-set" data-title="The next image in the set is preloaded as you're viewing." data-exif="SuperCool Camera1000 | f/10.0 | 1/2000 | ISO 200"><img class="example-image" src="img/demopage/thumb-5.jpg" alt="" /></a>
+						<a class="example-image-link" href="img/demopage/image-5.jpg" data-lightbox="example-set" data-title="The next image in the set is preloaded as you're viewing." data-exif="Nikon D80 | f/10.0 | 1/2000 | ISO 200"><img class="example-image" src="img/demopage/thumb-5.jpg" alt="" /></a>
 						<a class="example-image-link" href="img/demopage/image-6.jpg" data-lightbox="example-set" data-title="Click anywhere outside the image or the X to the right to close."><img class="example-image" src="img/demopage/thumb-6.jpg" alt="" /></a>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -62,9 +62,9 @@
 
 				<div class="image-row">
 					<div class="image-set">
-						<a class="example-image-link" href="img/demopage/image-3.jpg" data-lightbox="example-set" data-title="Click the right half of the image to move forward."><img class="example-image" src="img/demopage/thumb-3.jpg" alt=""/></a>
-						<a class="example-image-link" href="img/demopage/image-4.jpg" data-lightbox="example-set" data-title="Or press the right arrow on your keyboard."><img class="example-image" src="img/demopage/thumb-4.jpg" alt="" /></a>
-						<a class="example-image-link" href="img/demopage/image-5.jpg" data-lightbox="example-set" data-title="The next image in the set is preloaded as you're viewing."><img class="example-image" src="img/demopage/thumb-5.jpg" alt="" /></a>
+						<a class="example-image-link" href="img/demopage/image-3.jpg" data-lightbox="example-set" data-title="Click the right half of the image to move forward." data-exif="Nikon D5100 | f/8.0 | 1/400 | ISO 200"><img class="example-image" src="img/demopage/thumb-3.jpg" alt=""/></a>
+						<a class="example-image-link" href="img/demopage/image-4.jpg" data-lightbox="example-set" data-title="Or press the right arrow on your keyboard." data-exif="Nikon D300 | f/22.0 | 1/20 | ISO 200"><img class="example-image" src="img/demopage/thumb-4.jpg" alt="" /></a>
+						<a class="example-image-link" href="img/demopage/image-5.jpg" data-lightbox="example-set" data-title="The next image in the set is preloaded as you're viewing." data-exif="SuperCool Camera1000 | f/10.0 | 1/2000 | ISO 200"><img class="example-image" src="img/demopage/thumb-5.jpg" alt="" /></a>
 						<a class="example-image-link" href="img/demopage/image-6.jpg" data-lightbox="example-set" data-title="Click anywhere outside the image or the X to the right to close."><img class="example-image" src="img/demopage/thumb-6.jpg" alt="" /></a>
 					</div>
 				</div>

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -58,7 +58,7 @@
     // Attach event handlers to the new DOM elements. click click click
     Lightbox.prototype.build = function() {
       var self = this;
-      $("<div id='lightboxOverlay' class='lightboxOverlay'></div><div id='lightbox' class='lightbox'><div class='lb-outerContainer'><div class='lb-container'><img class='lb-image' src='' /><div class='lb-nav'><a class='lb-prev' href='' ></a><a class='lb-next' href='' ></a></div><div class='lb-loader'><a class='lb-cancel'></a></div></div></div><div class='lb-dataContainer'><div class='lb-data'><div class='lb-details'><span class='lb-caption'></span><span class='lb-number'></span></div><div class='lb-closeContainer'><a class='lb-close'></a></div></div></div></div>").appendTo($('body'));
+      $("<div id='lightboxOverlay' class='lightboxOverlay'></div><div id='lightbox' class='lightbox'><div class='lb-outerContainer'><div class='lb-container'><img class='lb-image' src='' /><div class='lb-nav'><a class='lb-prev' href='' ></a><a class='lb-next' href='' ></a></div><div class='lb-loader'><a class='lb-cancel'></a></div></div></div><div class='lb-dataContainer'><div class='lb-data'><div class='lb-details'><span class='lb-caption'></span><span class='lb-exif'></span><span class='lb-number'></span></div><div class='lb-closeContainer'><a class='lb-close'></a></div></div></div></div>").appendTo($('body'));
       
       // Cache jQuery objects
       this.$lightbox       = $('#lightbox');
@@ -135,7 +135,8 @@
       function addToAlbum($link) {
         self.album.push({
           link: $link.attr('href'),
-          title: $link.attr('data-title') || $link.attr('title')
+          title: $link.attr('data-title') || $link.attr('title'),
+          exif: $link.data('exif')
         });
       }
 
@@ -329,6 +330,9 @@
           .find('a').on('click', function(event){
             location.href = $(this).attr('href');
           });
+        // Grab the exif data and put it in the <span>
+        this.$lightbox.find('.lb-exif')
+          .html(this.album[this.currentImageIndex].exif);
       }
     
       if (this.album.length > 1 && this.options.showImageNumberLabel) {

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -189,7 +189,7 @@
       this.$overlay.fadeIn(this.options.fadeDuration);
 
       $('.lb-loader').fadeIn('slow');
-      this.$lightbox.find('.lb-image, .lb-nav, .lb-prev, .lb-next, .lb-dataContainer, .lb-numbers, .lb-caption').hide();
+      this.$lightbox.find('.lb-image, .lb-nav, .lb-prev, .lb-next, .lb-dataContainer, .lb-numbers, .lb-caption, .lb-exif').hide();
 
       this.$outerContainer.addClass('animating');
 
@@ -330,11 +330,15 @@
           .find('a').on('click', function(event){
             location.href = $(this).attr('href');
           });
-        // Grab the exif data and put it in the <span>
-        this.$lightbox.find('.lb-exif')
-          .html(this.album[this.currentImageIndex].exif);
       }
     
+      if (typeof this.album[this.currentImageIndex].exif !== 'undefined' && this.album[this.currentImageIndex].exif !== "") {
+      	// Grab the exif data and put it in the <span>
+        this.$lightbox.find('.lb-exif')
+          .html(this.album[this.currentImageIndex].exif)
+          .fadeIn('fast');
+      }
+
       if (this.album.length > 1 && this.options.showImageNumberLabel) {
         this.$lightbox.find('.lb-number').text(this.options.albumLabel(this.currentImageIndex + 1, this.album.length)).fadeIn('fast');
       } else {


### PR DESCRIPTION
I added a new data field (like title and link) so the user can specify EXIF data (things like the camera, focal length, film speed, etc.) using a data-exif attribute in the link. I added some bogus EXIF data to the demo HTML page; it displays in the same color as the number but the same text size as the title. This should make it clear the the EXIF information supports the title but is still more interesting than the number.