### PR TITLE
Improved Bower configuration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,6 @@
     "bower_components",
     "releases",
     "test",
-    "tests",
-    "js/jquery*.*"
+    "tests"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "Gruntfile.js",
     "node_modules",
     "bower_components",
+    "releases",
     "test",
     "tests"
   ]

--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "bower_components",
     "releases",
     "test",
-    "tests"
+    "tests",
+    "js/jquery*.*"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,9 @@
     "images"
   ],
   "license": "CC BY 2.5",
+  "dependencies": {
+    "jquery": "~1.11.0"
+  },
   "ignore": [
     "**/.*",
     "Gruntfile.js",


### PR DESCRIPTION
If you're currently downloading the library through Bower, there are several points that could be improved:

1. The **/releases** folder is included in the library. This means you have archives of other versions while managing your dependencies through Bower. This is not necessary because you already have your dependency manager to download the correct version of the library.
It also takes up 3/4 of the actual library (6.5M of 8.4MB).

2. **jQuery** should be marked as a dependency so that it's managed by Bower and not by this library. I kept the original jQuery JavaScript files to keep the demopage working, but it would be useful if the demopage would be using the Bower managed jQuery as well (or should be placed in a seperate demo folder to avoid confusion).