### PR TITLE
Access to lightbox options

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -66,7 +66,7 @@
       this.$outerContainer = this.$lightbox.find('.lb-outerContainer');
       this.$container      = this.$lightbox.find('.lb-container');
       
-       // Enabled public access to lightbox instance throw #lightbox to change options
+       // Enabled public access to lightbox instance throw #lightbox to change options 
       this.$lightbox.data('lightbox',this);
       
       // Store css values for future lookup

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -66,7 +66,7 @@
       this.$outerContainer = this.$lightbox.find('.lb-outerContainer');
       this.$container      = this.$lightbox.find('.lb-container');
       
-       // Enabled public access to lightbox instance throw #lightbox dom
+       // Enabled public access to lightbox instance throw #lightbox to change options
       this.$lightbox.data('lightbox',this);
       
       // Store css values for future lookup

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -65,6 +65,8 @@
       this.$overlay        = $('#lightboxOverlay');
       this.$outerContainer = this.$lightbox.find('.lb-outerContainer');
       this.$container      = this.$lightbox.find('.lb-container');
+      
+       // Enabled public access to lightbox instance throw #lightbox dom
       this.$lightbox.data('lightbox',this);
       
       // Store css values for future lookup

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -65,7 +65,8 @@
       this.$overlay        = $('#lightboxOverlay');
       this.$outerContainer = this.$lightbox.find('.lb-outerContainer');
       this.$container      = this.$lightbox.find('.lb-container');
-
+      this.$lightbox.data('lightbox',this);
+      
       // Store css values for future lookup
       this.containerTopPadding = parseInt(this.$container.css('padding-top'), 10);
       this.containerRightPadding = parseInt(this.$container.css('padding-right'), 10);


### PR DESCRIPTION
Enabled public access to lightbox instance throw #lightbox to change options
Example:
$('#lightbox').data('lightbox').options.resizeDuration=200;
	$('#lightbox').data('lightbox').options.albumLabel  = function(curImageNum, albumSize) {
		return "Изображение " + curImageNum + " из " + albumSize;
    };
