### PR TITLE
Fix positioning when scrolling

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -176,6 +176,17 @@
       }).fadeIn(this.options.fadeDuration);
 
       this.changeImage(imageNumber);
+      
+      $(window).scroll(
+        function(event)
+        {
+            var top = self.options.positionFromTop + $(this).scrollTop();
+            var left = $(this).scrollLeft();
+            self.$lightbox.css({
+                                top: top + 'px',
+                                left: left + 'px'
+                               });    
+        });
     };
 
     // Hide most UI elements in preparation for the animated resizing of the lightbox.


### PR DESCRIPTION
If lightbox was opened at the bottom of the page and then we started scrolling up, lightbox would sit at the bottom. It now correctly updates its position on window.scroll event