### PR TITLE
Updated lightbox.js to halve the dimensions of images marked with '@2x'

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -200,6 +200,12 @@
 
         $preloader = $(preloader);
 
+        var image_is_retina = self.album[imageNumber].link.indexOf('@2x') >= 0;
+        if (image_is_retina) {
+            preloader.width /= 2;
+            preloader.height /= 2;
+        }
+        
         $image.width(preloader.width);
         $image.height(preloader.height);
         


### PR DESCRIPTION
This is addressing Issue #432, so that retina images display at their correct size.