### PR TITLE
Change AMD jQuery require statement to use all lowercase.

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -14,12 +14,12 @@
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(['jQuery'], factory);
+        define(['jquery'], factory);
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports,
         // like Node.
-        module.exports = factory(require('jQuery'));
+        module.exports = factory(require('jquery'));
     } else {
         // Browser globals (root is window)
         root.lightbox = factory(root.jQuery);


### PR DESCRIPTION
jQuery recommends using all lowercase when supporting AMD. Currently, this will fail if jQuery is bundled with other modules.

http://requirejs.org/docs/jquery.html#modulename
https://github.com/jquery/jquery/blob/master/src/exports/amd.js