### PR TITLE
fix bug with content not loaded yet on lightbox initialization

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -60,8 +60,11 @@
   };
 
   Lightbox.prototype.init = function() {
-    this.enable();
-    this.build();
+    var self = this;
+    $(function () {
+      self.enable();
+      self.build();
+    });
   };
 
   // Loop through anchors and areamaps looking for either data-lightbox attributes or rel attributes


### PR DESCRIPTION
For instance, if the script is placed in the <head> area, with current code it will not see any images. The proposed fix solves this issue.