### PR TITLE
Preserve the image transform

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -155,7 +155,8 @@
     function addToAlbum($link) {
       self.album.push({
         link: $link.attr('href'),
-        title: $link.attr('data-title') || $link.attr('title')
+        title: $link.attr('data-title') || $link.attr('title'),
+        transform: $link.children(':first').css('transform')
       });
     }
 
@@ -224,6 +225,7 @@
       var windowWidth;
 
       $image.attr('src', self.album[imageNumber].link);
+      $image.css('transform', self.album[imageNumber].transform);
 
       $preloader = $(preloader);
 


### PR DESCRIPTION
When a css transform property is used in the base image, the preview should preserve it.
It's useful when an image is for example rotated on display