### PR TITLE
Bugfix - MaxHeight wouldn't work.

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -302,7 +302,7 @@
         if (self.options.maxWidth && self.options.maxWidth < maxImageWidth) {
           maxImageWidth = self.options.maxWidth;
         }
-        if (self.options.maxHeight && self.options.maxHeight < maxImageWidth) {
+        if (self.options.maxHeight && self.options.maxHeight < maxImageHeight) {
           maxImageHeight = self.options.maxHeight;
         }
 


### PR DESCRIPTION
Seems like there is a bug in line 306, the code is comparing against width but we want height.

Previously the 'maxHeight' in lightbox.options, wouldn't work properly.
I tested it after correcting and now the image is resizing properly.