### PR TITLE
Responsive img srcset support

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -207,8 +207,9 @@
     var imageNumber = 0;
 
     function addToAlbum($link) {
+      var src = $link.find('img')[0].currentSrc;
       self.album.push({
-        link: $link.attr('href'),
+        link: src || $link.attr('href'),
         title: $link.attr('data-title') || $link.attr('title')
       });
     }


### PR DESCRIPTION
get img src from img inside link tag if exist.
example: <a href="pic.jpg"><img src="pic.jpg" srcset="pic-320.jpg 320w, pic-480.jpg 480w" ></a>
it takes img src browser is using.