### PR TITLE
Adding alt attribute for lb-image

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -282,7 +282,10 @@
       var windowHeight;
       var windowWidth;
 
-      $image.attr('src', self.album[imageNumber].link);
+      $image.attr({
+        'src': self.album[imageNumber].link,
+        'alt': self.album[imageNumber].title
+      });
 
       $preloader = $(preloader);
 


### PR DESCRIPTION
the alt attribute is required by html spec and also necessary for screen-reader users to perceive the contents of images. This adds the image title as alt attribute to lb-image.

This should fix #571, #364