### PR TITLE
Fix: Remove image files from bower json main prop

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,11 +7,7 @@
   "description": "The original Lightbox script. Uses jQuery.",
   "main": [
     "./dist/js/lightbox.js",
-    "./dist/css/lightbox.css",
-    "./dist/images/close.png",
-    "./dist/images/loading.gif",
-    "./dist/images/next.png",
-    "./dist/images/prev.png"
+    "./dist/css/lightbox.css"
   ],
   "keywords": [
     "lightbox",


### PR DESCRIPTION
Fixes: https://github.com/lokesh/lightbox2/issues/586


```
bower not-cached    https://github.com/lokesh/lightbox2.git#*
bower resolve       https://github.com/lokesh/lightbox2.git#*
bower download      https://github.com/lokesh/lightbox2/archive/v2.9.0.tar.gz
bower extract       lightbox2#* archive.tar.gz
bower invalid-meta  for:/var/folders/t3/lrrqhsh93s33gmwvfk8xlv0r0000gn/T/User/bower/a08e0fb2a5ef407322a40916669bdd9d-24812-qnTvTV/bower.json
bower invalid-meta  The "main" field cannot contain font, image, audio, or video files
bower invalid-meta  The "main" field cannot contain font, image, audio, or video files
bower invalid-meta  The "main" field cannot contain font, image, audio, or video files
bower invalid-meta  The "main" field cannot contain font, image, audio, or video files
bower invalid-meta  The "main" field has to contain only 1 file per filetype; found multiple .png files: ["./dist/images/close.png","./dist/images/next.png","./dist/images/prev.png"]
```