### PR TITLE
added option to define a different start image

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -14,18 +14,18 @@
 
 // Uses Node, AMD or browser globals to create a module.
 (function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['jquery'], factory);
-    } else if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory(require('jquery'));
-    } else {
-        // Browser globals (root is window)
-        root.lightbox = factory(root.jQuery);
-    }
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory(require('jquery'));
+  } else {
+    // Browser globals (root is window)
+    root.lightbox = factory(root.jQuery);
+  }
 }(this, function ($) {
 
   function Lightbox(options) {
@@ -53,13 +53,14 @@
     showImageNumberLabel: true,
     wrapAround: false,
     disableScrolling: false,
+    imageToStartWith: false,
     /*
-    Sanitize Title
-    If the caption data is trusted, for example you are hardcoding it in, then leave this to false.
-    This will free you to add html tags, such as links, in the caption.
+     Sanitize Title
+     If the caption data is trusted, for example you are hardcoding it in, then leave this to false.
+     This will free you to add html tags, such as links, in the caption.
 
-    If the caption data is user submitted or from some other untrusted source, then set this to true
-    to prevent xss and other injection attacks.
+     If the caption data is user submitted or from some other untrusted source, then set this to true
+     to prevent xss and other injection attacks.
      */
     sanitizeTitle: false
   };
@@ -95,7 +96,7 @@
   // Attach event handlers to the new DOM elements. click click click
   Lightbox.prototype.build = function() {
     if ($('#lightbox').length > 0) {
-        return;
+      return;
     }
 
     var self = this;
@@ -163,17 +164,17 @@
     });
 
     /*
-      Show context menu for image on right-click
+     Show context menu for image on right-click
 
-      There is a div containing the navigation that spans the entire image and lives above of it. If
-      you right-click, you are right clicking this div and not the image. This prevents users from
-      saving the image or using other context menu actions with the image.
+     There is a div containing the navigation that spans the entire image and lives above of it. If
+     you right-click, you are right clicking this div and not the image. This prevents users from
+     saving the image or using other context menu actions with the image.
 
-      To fix this, when we detect the right mouse button is pressed down, but not yet clicked, we
-      set pointer-events to none on the nav div. This is so that the upcoming right-click event on
-      the next mouseup will bubble down to the image. Once the right-click/contextmenu event occurs
-      we set the pointer events back to auto for the nav div so it can capture hover and left-click
-      events as usual.
+     To fix this, when we detect the right mouse button is pressed down, but not yet clicked, we
+     set pointer-events to none on the nav div. This is so that the upcoming right-click event on
+     the next mouseup will bubble down to the image. Once the right-click/contextmenu event occurs
+     we set the pointer events back to auto for the nav div so it can capture hover and left-click
+     events as usual.
      */
     this.$nav.on('mousedown', function(event) {
       if (event.which === 3) {
@@ -181,7 +182,7 @@
 
         self.$lightbox.one('contextmenu', function() {
           setTimeout(function() {
-              this.$nav.css('pointer-events', 'auto');
+            this.$nav.css('pointer-events', 'auto');
           }.bind(self), 0);
         });
       }
@@ -245,6 +246,11 @@
         }
       }
     }
+
+    if(self.options.imageToStartWith !== false) {
+      imageNumber = self.options.imageToStartWith;
+    }
+
 
     // Position Lightbox
     var top  = $window.scrollTop() + this.options.positionFromTop;
@@ -340,8 +346,8 @@
   // Stretch overlay to fit the viewport
   Lightbox.prototype.sizeOverlay = function() {
     this.$overlay
-      .width($(document).width())
-      .height($(document).height());
+        .width($(document).width())
+        .height($(document).height());
   };
 
   // Animate the size of the lightbox to fit the image we are showing
@@ -426,7 +432,7 @@
     // Enable anchor clicks in the injected caption html.
     // Thanks Nate Wright for the fix. @https://github.com/NateWr
     if (typeof this.album[this.currentImageIndex].title !== 'undefined' &&
-      this.album[this.currentImageIndex].title !== '') {
+        this.album[this.currentImageIndex].title !== '') {
       var $caption = this.$lightbox.find('.lb-caption');
       if (this.options.sanitizeTitle) {
         $caption.text(this.album[this.currentImageIndex].title);
@@ -434,13 +440,13 @@
         $caption.html(this.album[this.currentImageIndex].title);
       }
       $caption.fadeIn('fast')
-        .find('a').on('click', function(event) {
-          if ($(this).attr('target') !== undefined) {
-            window.open($(this).attr('href'), $(this).attr('target'));
-          } else {
-            location.href = $(this).attr('href');
-          }
-        });
+          .find('a').on('click', function(event) {
+        if ($(this).attr('target') !== undefined) {
+          window.open($(this).attr('href'), $(this).attr('target'));
+        } else {
+          location.href = $(this).attr('href');
+        }
+      });
     }
 
     if (this.album.length > 1 && this.options.showImageNumberLabel) {


### PR DESCRIPTION
Added an option to select an image to start with. In my particular use case the first image was a logo and when clicked, the lightbox should open with the first 'real' image. So I used the following options:

`lightbox.option({
        'resizeDuration': 200,
        'wrapAround': true,
        'imageToStartWith': 1
    })`