### PR TITLE
Fix too much unused space on mobile, landscape view

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -304,7 +304,7 @@
         windowWidth    = $(window).width();
         windowHeight   = $(window).height();
         maxImageWidth  = windowWidth - self.containerPadding.left - self.containerPadding.right - self.imageBorderWidth.left - self.imageBorderWidth.right - 20;
-        maxImageHeight = windowHeight - self.containerPadding.top - self.containerPadding.bottom - self.imageBorderWidth.top - self.imageBorderWidth.bottom - 120;
+        maxImageHeight = windowHeight - self.containerPadding.top - self.containerPadding.bottom - self.imageBorderWidth.top - self.imageBorderWidth.bottom - 45 - self.$lightbox[0].offsetTop;
 
         // Check if image size is larger then maxWidth|maxHeight in settings
         if (self.options.maxWidth && self.options.maxWidth < maxImageWidth) {


### PR DESCRIPTION
Hi,

lightbox2 is great, I only have a single issue with it, namely too much unused space on mobile, landscape view:
![landscape issue](https://user-images.githubusercontent.com/7656530/52281924-700c5880-295f-11e9-820d-2f2cd956a369.png)

In lightbox.js I find the magic number "120"
`!         maxImageHeight = windowHeight - self.containerPadding.top - self.containerPadding.bottom - self.imageBorderWidth.top - self.imageBorderWidth.bottom - 120;`

I'm not sure what this is about. I may be wrong, but it seems the only height that needs to be subtracted is the top offset and the "lb-dataContainer" height below the image (45px in my case), thous:

`maxImageHeight = windowHeight - self.containerPadding.top - self.containerPadding.bottom - self.imageBorderWidth.top - self.imageBorderWidth.bottom - 45 - self.$lightbox[0].offsetTop;`

Now, when my site is in mobile mode, I can set #lightbox "top" to 0:
`
@media screen and (max-width: 1050px)
{
    #lightbox
    {
        top: 0 !important;
    }
}
`

And everything looks great, with no space wasted:
![landscape fixed](https://user-images.githubusercontent.com/7656530/52282252-469ffc80-2960-11e9-8c46-f04169852643.png)