### PR TITLE
Don't toggle visibility of select, embed, object

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -201,10 +201,6 @@
 
     $window.on('resize', $.proxy(this.sizeOverlay, this));
 
-    $('select, object, embed').css({
-      visibility: 'hidden'
-    });
-
     this.sizeOverlay();
 
     this.album = [];
@@ -534,9 +530,7 @@
     $(window).off('resize', this.sizeOverlay);
     this.$lightbox.fadeOut(this.options.fadeDuration);
     this.$overlay.fadeOut(this.options.fadeDuration);
-    $('select, object, embed').css({
-      visibility: 'visible'
-    });
+
     if (this.options.disableScrolling) {
       $('body').removeClass('lb-disable-scrolling');
     }


### PR DESCRIPTION
This was done to fix issues in older versions of IE that had their `<select>` components peeking through the Lightbox overlay.

Removing this code fixes the reported issue: 
#520  Toggling visibility of elements on open/close revealing intentionally hidden elements. 
