### PR TITLE
Fix: incorrect image size when positionFromTop set

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -299,7 +299,7 @@
       // Calculate the max image dimensions for the current viewport.
       // Take into account the border around the image and an additional 10px gutter on each side.
       maxImageWidth  = windowWidth - self.containerPadding.left - self.containerPadding.right - self.imageBorderWidth.left - self.imageBorderWidth.right - 20;
-      maxImageHeight = windowHeight - self.containerPadding.top - self.containerPadding.bottom - self.imageBorderWidth.top - self.imageBorderWidth.bottom - 120;
+      maxImageHeight = windowHeight - self.containerPadding.top - self.containerPadding.bottom - self.imageBorderWidth.top - self.imageBorderWidth.bottom - self.options.positionFromTop - 70;
 
       /*
       SVGs that don't have width and height attributes specified are reporting width and height


### PR DESCRIPTION
> When changing the positionFromTop setting the images height is not adjusted. This pull request fixes the height

Fix by @martijndebruijn 

Original PR: https://github.com/lokesh/lightbox2/pull/645