### PR TITLE
fix: use max[Width|Height] when fitImagesInViewport is false

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -327,20 +327,24 @@
           maxImageHeight = self.options.maxHeight;
         }
 
-        // Is the current image's width or height is greater than the maxImageWidth or maxImageHeight
-        // option than we need to size down while maintaining the aspect ratio.
-        if ((preloader.width > maxImageWidth) || (preloader.height > maxImageHeight)) {
-          if ((preloader.width / maxImageWidth) > (preloader.height / maxImageHeight)) {
-            imageWidth  = maxImageWidth;
-            imageHeight = parseInt(preloader.height / (preloader.width / imageWidth), 10);
-            $image.width(imageWidth);
-            $image.height(imageHeight);
-          } else {
-            imageHeight = maxImageHeight;
-            imageWidth = parseInt(preloader.width / (preloader.height / imageHeight), 10);
-            $image.width(imageWidth);
-            $image.height(imageHeight);
-          }
+      } else {
+        maxImageWidth = self.options.maxWidth || preloader.width || maxImageWidth;
+        maxImageHeight = self.options.maxHeight || preloader.height || maxImageHeight;
+      }
+
+      // Is the current image's width or height is greater than the maxImageWidth or maxImageHeight
+      // option than we need to size down while maintaining the aspect ratio.
+      if ((preloader.width > maxImageWidth) || (preloader.height > maxImageHeight)) {
+        if ((preloader.width / maxImageWidth) > (preloader.height / maxImageHeight)) {
+          imageWidth  = maxImageWidth;
+          imageHeight = parseInt(preloader.height / (preloader.width / imageWidth), 10);
+          $image.width(imageWidth);
+          $image.height(imageHeight);
+        } else {
+          imageHeight = maxImageHeight;
+          imageWidth = parseInt(preloader.width / (preloader.height / imageHeight), 10);
+          $image.width(imageWidth);
+          $image.height(imageHeight);
         }
       }
       self.sizeContainer($image.width(), $image.height());


### PR DESCRIPTION
> Pull Requests are welcome. But v2 of Lightbox is in Maintenance Mode. 
> No new features are planned. See the [Roadmap](https://github.com/lokesh/lightbox2/blob/master/ROADMAP.md).
> 
> PRs submitted will still be reviewed and kept open for others to utilize.

Hi, I like lightbox.

When fitImagesInViewport option is false, maxWidth and maxHeight is ignore.
But I want to use the following option for large and long image(e.g.: 1920x4320).

```js
lightbox.option({
  'fitImagesInViewport': false,
  'maxWidth': 800
})
```

This PR modify to use maxWidth and maxHeight when fitImagesInViewport is false.