### PR TITLE
Resize overlay issue

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -379,8 +379,8 @@
     */
     setTimeout(function() {
       self.$overlay
-        .width($(document).width())
-        .height($(document).height());
+        .width($(window).width())
+        .height($(window).height());
 
     }, 0);
   };


### PR DESCRIPTION
The current function doesn't work well when the viewport is resized to a smaller size as the document width and height remains bigger than the window size

> Pull Requests are welcome. But v2 of Lightbox is in Maintenance Mode. 
> No new features are planned. See the [Roadmap](https://github.com/lokesh/lightbox2/blob/master/ROADMAP.md).
> 
> PRs submitted will still be reviewed and kept open for others to utilize.
