### PR TITLE
feat: When displaying SVGs, max out their size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lightbox2
 
-The original lightbox script. Eight years later — still going strong!
+The _original_ lightbox script.
 
 Lightbox is small javascript library used to overlay images on top of the current page. It's a snap to setup and works on all modern browsers.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightbox2",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "author": "Lokesh Dhakar <lokesh.dhakar@gmail.com>",
   "description": "The original Lightbox script. Uses jQuery.",
   "keywords": [

--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -1,5 +1,5 @@
 /*!
- * Lightbox v2.11.1
+ * Lightbox v2.11.2
  * by Lokesh Dhakar
  *
  * More info:

--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -314,18 +314,13 @@
       maxImageHeight = windowHeight - self.containerPadding.top - self.containerPadding.bottom - self.imageBorderWidth.top - self.imageBorderWidth.bottom - self.options.positionFromTop - 70;
 
       /*
-      SVGs that don't have width and height attributes specified are reporting width and height
-      values of 0 in Firefox 47 and IE11 on Windows. To fix, we set the width and height to the max
-      dimensions for the viewport rather than 0 x 0.
-
-      https://github.com/lokesh/lightbox2/issues/552
+      Since many SVGs have small intrinsic dimensions, but they support scaling
+      up without quality loss because of their vector format, max out their
+      size.
       */
-
       if (filetype === 'svg') {
-        if ((preloader.width === 0) || preloader.height === 0) {
-          $image.width(maxImageWidth);
-          $image.height(maxImageHeight);
-        }
+        $image.width(maxImageWidth);
+        $image.height(maxImageHeight);
       }
 
       // Fit image inside the viewport.


### PR DESCRIPTION
SVGs are often constructed to be scaled up and down to various sizes, and since SVGs are a primarily vector format, they can be scaled up and down without quality loss. Many of these SVG files are constructed w/o consideration of the viewbox dimensions. Some are tiny, and some are massive. When they are rendered on a site, these intrinsic dimensions don't matter much, as they are almost always resized for the layout context (e.g. svg { width: 100%; }).

**How does this affect Lightbox?** When using SVGs with Lightbox, we are seeing some files render very tiny. This is because of their small intrinsic dimensions.
![image](https://user-images.githubusercontent.com/51469/86504366-4e89e900-bd6c-11ea-8159-6cc3ed060ae0.png)

To resolve this issue, when an SVG is loaded in Lightbox, rather than reading the width and height, we max out the image in the viewport.

---
https://github.com/lokesh/lightbox2/issues/681

@davidc Considering this update to resolve your issue. 