### PR TITLE
jQuery 3.5: Don't use shorthand $.focus()

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -396,7 +396,7 @@
       self.$lightbox.find('.lb-nextLink').height(newHeight);
 
       // Set focus on one of the two root nodes so keyboard events are captured.
-      self.$overlay.focus();
+      self.$overlay.trigger( 'focus' );
 
       self.showImage();
     }


### PR DESCRIPTION
$.focus() shorthand is deprecated in jQuery 3.0. Without this change jQuery Migrate is required.

https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryfnclick-event-shorthand-is-deprecated