### PR TITLE
Fix: SVG scaling when file extension is not lower case

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -277,7 +277,7 @@
   Lightbox.prototype.changeImage = function(imageNumber) {
     var self = this;
     var filename = this.album[imageNumber].link;
-    var filetype = filename.split('.').slice(-1)[0];
+    var filetype = filename.split('.').slice(-1)[0].toLowerCase();
     var $image = this.$lightbox.find('.lb-image');
 
     // Disable keyboard nav during transitions


### PR DESCRIPTION
If an SVG image has an file extension that is not in lower case, the image will not be scaled. This PR fixes this problem.
