### PR TITLE
fix: preload did not take into account the wrapAround option

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -510,13 +510,18 @@
 
   // Preload previous and next images in set.
   Lightbox.prototype.preloadNeighboringImages = function() {
-    if (this.album.length > this.currentImageIndex + 1) {
-      var preloadNext = new Image();
-      preloadNext.src = this.album[this.currentImageIndex + 1].link;
-    }
-    if (this.currentImageIndex > 0) {
-      var preloadPrev = new Image();
-      preloadPrev.src = this.album[this.currentImageIndex - 1].link;
+    var indexes = [ this.currentImageIndex - 1, this.currentImageIndex + 1 ];
+    for (var i = 0; i < 2; i++) {
+      var index = indexes[i];
+      if (index >= this.album.length) {
+        if (!this.options.wrapAround) continue;
+        index = 0;
+      } else if (index < 0) {
+        if (!this.options.wrapAround) continue;
+        index = this.album.length - 1;
+      }
+      var preload = new Image();
+      preload.src = this.album[index].link;
     }
   };
 


### PR DESCRIPTION
PR fixes the preloadNeighboringImages function so that it preloads the last and first image when the first and last image respectively are displayed if the wrapAround option is active